### PR TITLE
Parallel streaming upload

### DIFF
--- a/b2.cabal
+++ b/b2.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 602e7a916ae4ad2da2e049ee007c234c54ba4e72cd9393c69bc851764ac2d8d8
+-- hash: b6572faef956ab5bbf6395a1d9cf7206cb0aa6b7592135271c0dcc6ab3d73ed7
 
 name:           b2
 version:        1.0.0
@@ -36,6 +36,7 @@ library
     , http-conduit
     , http-types
     , resourcet
+    , safe-exceptions
     , text
     , unordered-containers
     , vector

--- a/b2.cabal
+++ b/b2.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b6572faef956ab5bbf6395a1d9cf7206cb0aa6b7592135271c0dcc6ab3d73ed7
+-- hash: d393af900a651bee34c90ccdca82059549f69b321ef71acf438931c3701cc758
 
 name:           b2
 version:        1.0.0
@@ -23,7 +23,7 @@ library
   hs-source-dirs:
       src
   default-extensions: OverloadedStrings
-  ghc-options: -funbox-strict-fields -Wall -Werror
+  ghc-options: -funbox-strict-fields -Wall
   build-depends:
       aeson
     , base >=4.7 && <5

--- a/b2.cabal
+++ b/b2.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d393af900a651bee34c90ccdca82059549f69b321ef71acf438931c3701cc758
+-- hash: 6d4abd5830e13f67bdc04eaa73b0c5ca6b935d8793b1c8ab727b0de63c9f41da
 
 name:           b2
 version:        1.0.0
@@ -28,7 +28,6 @@ library
       aeson
     , base >=4.7 && <5
     , bytestring
-    , bytestring-to-vector
     , case-insensitive
     , conduit
     , conduit-concurrent-map
@@ -44,6 +43,7 @@ library
       B2
       B2.AuthorizationToken
       B2.Bucket
+      B2.Chunk
       B2.File
       B2.ID
       B2.Key

--- a/b2.cabal
+++ b/b2.cabal
@@ -1,8 +1,10 @@
--- This file has been generated from package.yaml by hpack version 0.28.2.
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: bf7ab7514cbdddc3c7ce3dc782429cdacf90b5b2b598a3d6bf12917695159107
+-- hash: 602e7a916ae4ad2da2e049ee007c234c54ba4e72cd9393c69bc851764ac2d8d8
 
 name:           b2
 version:        1.0.0
@@ -14,7 +16,6 @@ copyright:      Matvey Aksenov 2018
 license:        BSD2
 license-file:   LICENSE
 build-type:     Simple
-cabal-version:  >= 1.10
 extra-source-files:
     README.markdown
 
@@ -27,14 +28,17 @@ library
       aeson
     , base >=4.7 && <5
     , bytestring
+    , bytestring-to-vector
     , case-insensitive
     , conduit
+    , conduit-concurrent-map
     , cryptonite
     , http-conduit
     , http-types
     , resourcet
     , text
     , unordered-containers
+    , vector
   exposed-modules:
       B2
       B2.AuthorizationToken

--- a/cli/b2-cli.cabal
+++ b/cli/b2-cli.cabal
@@ -1,8 +1,10 @@
--- This file has been generated from package.yaml by hpack version 0.28.2.
+cabal-version: 1.24
+
+-- This file has been generated from package.yaml by hpack version 0.31.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 67fade2d76fe334520a30779e852b050c84e3bd3d96b76d147cf5d055aa26252
+-- hash: ef59357e2e3496bf1b707403dbe4af3c0ffb56019fc4af4c88599db785bd9e0c
 
 name:           b2-cli
 version:        1.0.0
@@ -13,7 +15,6 @@ maintainer:     matvey.aksenov@gmail.com
 copyright:      Matvey Aksenov 2018
 license:        BSD2
 build-type:     Custom
-cabal-version:  >= 1.24
 extra-source-files:
     README.markdown
 

--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,7 @@ library:
     - http-conduit
     - http-types
     - resourcet
+    - safe-exceptions
     - text
     - unordered-containers
   source-dirs:

--- a/package.yaml
+++ b/package.yaml
@@ -19,6 +19,9 @@ library:
   dependencies:
     - aeson
     - bytestring
+    - bytestring-to-vector
+    - conduit-concurrent-map
+    - vector
     - case-insensitive
     - conduit
     - cryptonite

--- a/package.yaml
+++ b/package.yaml
@@ -36,7 +36,6 @@ library:
   ghc-options:
     - -funbox-strict-fields
     - -Wall
-    - -Werror
 
 tests:
   spec:

--- a/package.yaml
+++ b/package.yaml
@@ -19,7 +19,6 @@ library:
   dependencies:
     - aeson
     - bytestring
-    - bytestring-to-vector
     - conduit-concurrent-map
     - vector
     - case-insensitive

--- a/src/B2.hs
+++ b/src/B2.hs
@@ -862,8 +862,8 @@ streamUpload (Just chunkSize) env bucketID filename manager =
       case (input1, input2) of
         (Nothing, Nothing) -> liftIO $ error "no input"
         (Just (_, buffer), Nothing) -> do
+          -- retry: if uploading fails, we need to get new upload url
           liftIO $ retrySimple $ do
-            -- retry: if uploading fails, we need to get new upload url
             uploadUrl <- dieW (B2.get_upload_url env bucketID manager)
             dieW $ B2.upload_file uploadUrl filename (fromIntegral $ BS.length buffer) (yield buffer) Nothing Nothing manager
         (Just a, Just b) -> do
@@ -879,7 +879,6 @@ streamUpload (Just chunkSize) env bucketID filename manager =
 
     multiUpload :: LargeFile -> (Int, ByteString) -> (ResourceT IO) LargeFilePart
     multiUpload fileID (i, buffer) = liftIO $ retrySimple $ do
-      putStrLn $ show i
       url <- dieW $ B2.get_upload_part_url env fileID manager
       dieW $ B2.upload_part url (fromIntegral i) (fromIntegral $ BS.length buffer) (yield buffer) manager
 

--- a/src/B2.hs
+++ b/src/B2.hs
@@ -862,7 +862,7 @@ streamUpload (Just chunkSize) env bucketID filename manager =
     multiUploadConduit :: ConduitT (Int, ByteString) Void (ResourceT IO) File
     multiUploadConduit = do
       fileID <- liftIO $ retrySimple $ dieW (start_large_file env bucketID filename Nothing Nothing manager)
-      handleC (handler fileID) $ concurrentMapM_ 20 4 (multiUpload fileID) .| (finishMultiUploadConduit fileID)
+      handleC (handler fileID) $ concurrentMapM_ 3 1 (multiUpload fileID) .| (finishMultiUploadConduit fileID)
 
     multiUpload :: LargeFile -> (Int, ByteString) -> (ResourceT IO) LargeFilePart
     multiUpload fileID (i, buffer) = liftIO $ retrySimple $ do

--- a/src/B2.hs
+++ b/src/B2.hs
@@ -876,10 +876,7 @@ retry delaysSeconds io = loop delaysSeconds
       liftIO $ threadDelay (floor $ delay * 1000 * 1000)
       loop delays
 
-retryThreeTimes :: IO a -> IO a
-retryThreeTimes = retry [0.1, 0.3, 0.5]
-
 dieW :: (Exception e) => IO (Either e a) -> IO a
-dieW x = retryThreeTimes $ do
+dieW x = retry [0.0, 0.0, 0.1, 0.1, 0.1, 0.5, 0.5, 0.5] $ do
   res <- x
   either throwIO pure res

--- a/src/B2.hs
+++ b/src/B2.hs
@@ -880,7 +880,7 @@ streamUpload (Just chunkSize) env bucketID filename manager =
 
     handler :: (HasCallStack, MonadIO m) => LargeFile -> SomeException -> ConduitT i o m r
     handler fileID exc = liftIO $ do
-      _ <- retrySimple $ dieW $ B2.cancel_large_file env fileID manager
+      _ <- dieW $ B2.cancel_large_file env fileID manager
       putStrLn $ prettyCallStack callStack
       throwIO exc
 

--- a/src/B2.hs
+++ b/src/B2.hs
@@ -877,7 +877,7 @@ retry delaysSeconds io = loop delaysSeconds
       loop delays
 
 retryThreeTimes :: IO a -> IO a
-retryThreeTimes = retry [0, 0, 0]
+retryThreeTimes = retry [0.1, 0.3, 0.5]
 
 dieW :: (Exception e) => IO (Either e a) -> IO a
 dieW x = retryThreeTimes $ do

--- a/src/B2.hs
+++ b/src/B2.hs
@@ -21,7 +21,7 @@ module B2
   ) where
 
 import           Control.Concurrent (threadDelay)
-import           Control.Exception (Exception, throwIO, SomeException, catch)
+import           Control.Exception.Safe (Exception, throwIO, SomeException, catch)
 import           Control.Monad (join, forM_)
 import           Control.Monad.IO.Class (MonadIO(..))
 import           Control.Monad.Trans.Resource (MonadResource, ResourceT)

--- a/src/B2/Chunk.hs
+++ b/src/B2/Chunk.hs
@@ -1,0 +1,55 @@
+-- Chunking with a raw buffer
+module B2.Chunk 
+  ( chunkBySize
+  ) where
+
+import           Control.Monad.IO.Class        (MonadIO(..))
+import           Data.ByteString               (ByteString)
+import           Data.Word                     (Word8)
+import           Data.Conduit                  (ConduitT, await, yield)
+import           Foreign.ForeignPtr            (ForeignPtr)
+import           Foreign.ForeignPtr.Unsafe     (unsafeForeignPtrToPtr)
+import           Foreign.Ptr                   (Ptr)
+import qualified Data.ByteString as B
+import           Data.ByteString.Internal      (ByteString (PS), mallocByteString)
+import           Data.ByteString.Unsafe        (unsafeIndex)
+import           Foreign.Storable              (pokeByteOff)
+
+type ChunkSize = Int
+
+data S = S (ForeignPtr Word8) (Ptr Word8) {-# UNPACK #-} !Int
+
+newS :: ChunkSize -> IO S
+newS chunkSize = do
+    fptr <- mallocByteString chunkSize
+    return (S fptr (unsafeForeignPtrToPtr fptr) 0)
+
+processChunk :: ChunkSize -> ByteString -> S -> IO ([ByteString], S)
+processChunk chunkSize input =
+    loop id 0
+  where
+    loop front idxIn s@(S fptr ptr idxOut)
+        | idxIn >= B.length input = return (front [], s)
+        | otherwise = do
+            pokeByteOff ptr idxOut (unsafeIndex input idxIn)
+            let idxOut' = idxOut + 1
+                idxIn' = idxIn + 1
+            if idxOut' >= chunkSize
+                then do
+                    let bs = PS fptr 0 idxOut'
+                    s' <- newS chunkSize
+                    loop (front . (bs:)) idxIn' s'
+                else loop front idxIn' (S fptr ptr idxOut')
+
+chunkBySize :: MonadIO m => ChunkSize -> ConduitT ByteString ByteString m ()
+chunkBySize chunkSize =
+    liftIO (newS chunkSize) >>= loop
+  where
+    loop s@(S fptr _ len) = do
+        mbs <- await
+        case mbs of
+            Nothing -> yield $ PS fptr 0 len
+            Just bs -> do
+                (bss, s') <- liftIO $ processChunk chunkSize bs s
+                mapM_ yield bss
+                loop s'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.9
+resolver: lts-14.0
 packages:
   - '.'
   - './cli'


### PR DESCRIPTION
This is now used by https://cachix.org/ in production for about a month.

It was rewritten about two times. Latest iteration can handle 10MB/s uploads at about 30% CPU usage on my XPS 15.

There are two more issues to be considered:

- `{code = "bad_request", message = "No active upload for large file (redacted)", status = 400}` seems to trigger sometimes
- retries are sometimes not enough to save from transient errors, so probably need to add a few more (although on other hand I'm a bit wary just slamming lots of retries)